### PR TITLE
feat: 添加额外适配规则

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ module.exports = {
       2,
       'all',
     ],
+    'react/no-did-mount-set-state': 0,
+    'react/forbid-prop-types': 0,
+    'jsx-a11y/no-static-element-interactions': 0,
+    'array-callback-return': 0,
     'comma-dangle': ['error', {
       arrays: 'always-multiline',
       objects: 'always-multiline',


### PR DESCRIPTION
1. `react/no-did-mount-set-state: 0` 允许 react 组件在 `componentDidMount` 函数中调用 `setState`
2. `react/forbid-prop-types: 0` 允许 react 中模糊使用 prop-types，例如 `o: PropTypes.object`
3. `jsx-a11y/no-static-element-interactions: 0` 允许在 div, span 等元素上监听用户手势（如滑动）
4. `array-callback-return: 0` 允许箭头函数没有返回值